### PR TITLE
Corrections in Spanish

### DIFF
--- a/src/data/ts/es.ts
+++ b/src/data/ts/es.ts
@@ -266,7 +266,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+21"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;: If enabled, all other clients must share a common certificate authority (CA) and have TLS enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Aviso&lt;/span&gt;: Si permitido, todos de otros clientes necesitan compartir un autoridad de certificado commún (CA) y tienen TLS permitido.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Aviso&lt;/span&gt;: Si está activado, todos los demás clientes deben compartir un certificado de autoridad común (CA) y tener TLS habilitado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+10"/>
@@ -287,7 +287,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="-10"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning:&lt;/span&gt; Changing the settings below may cause NitroShare to stop functioning or use excessive bandwidth. Proceed with caution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Aviso:&lt;/span&gt; Cambiar las siguientes preferencias puede causar NitroShare a no funcionar o usa mucho ancho de banda. Usa con cuidado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Aviso:&lt;/span&gt; Cambiar los ajustes siguientes puede hacer que NitroShare deje de funcionar o utilizar excesivo ancho de banda. Proceda con precaución.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location line="+39"/>
@@ -328,7 +328,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+13"/>
         <source>Reset</source>
-        <translation>Reajustar</translation>
+        <translation>Restablecer</translation>
     </message>
     <message>
         <location filename="../../settings/settingsdialog.cpp" line="+78"/>
@@ -343,12 +343,12 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+13"/>
         <source>Confirm Reset</source>
-        <translation>Confirme Reajustar</translation>
+        <translation>Restablecer configuración</translation>
     </message>
     <message>
         <location line="+1"/>
         <source>Are you sure you want to reset all settings to their default values? This cannot be undone.</source>
-        <translation>¿Estás seguro que quieras reajustar todas las preferencias al valor por defecto?</translation>
+        <translation>¿Estás seguro que quieras restablecertodas las preferencias al valor por defecto?</translation>
     </message>
     <message>
         <location line="+30"/>

--- a/src/data/ts/es.ts
+++ b/src/data/ts/es.ts
@@ -86,12 +86,12 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+8"/>
         <source>%1 has joined.</source>
-        <translation>%1 ha juntado.</translation>
+        <translation>%1 se ha unido.</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>%1 has left.</source>
-        <translation>%1 ha salido.</translation>
+        <translation>%1 se ha desconectado.</translation>
     </message>
     <message>
         <location line="+16"/>
@@ -106,17 +106,17 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+5"/>
         <source>Transfer with %1 succeeded.</source>
-        <translation>Transferencia con %1 triunfó.</translation>
+        <translation>Transferencia con %1 satisfactoria.</translation>
     </message>
     <message>
         <location line="+22"/>
         <source>Select Files</source>
-        <translation>Selecciona Archivos</translation>
+        <translation>Seleccionar Archivos</translation>
     </message>
     <message>
         <location line="+15"/>
         <source>Select Directory</source>
-        <translation>Selecciona Directorio</translation>
+        <translation>Seleccionar Directorio</translation>
     </message>
 </context>
 <context>
@@ -124,12 +124,12 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location filename="../../device/devicedialog.ui" line="+14"/>
         <source>Select Device</source>
-        <translation>Selecciona Aparato</translation>
+        <translation>Seleccionar Dispositivo</translation>
     </message>
     <message>
         <location line="+10"/>
         <source>Select a device:</source>
-        <translation>Selecciona un aparato:</translation>
+        <translation>Selecciona un dispositivo:</translation>
     </message>
 </context>
 <context>
@@ -137,7 +137,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location filename="../../device/devicemodel.cpp" line="+190"/>
         <source>Device Name</source>
-        <translation>Nombre de Aparato</translation>
+        <translation>Nombre del Dispositivo</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -155,7 +155,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+0"/>
         <source>Some versions of Gnome do not support AppIndicators. This prevents NitroShare from displaying an indicator in the notification area. Please ensure you have this extension installed before continuing:&lt;br&gt;&lt;br&gt;&lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
-        <translation>Algunas versiones de Gnome no suportar AppIndicators. Este previene NitroShare a exponer un indicador en la área de notificaciónes. Por favor, asegura que tengas esta extensión antes continuar:&lt;br&gt;&lt;br&gt;&lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
+        <translation>Algunas versiones de Gnome no soportan AppIndicators. Esto evita que NitroShare muestre un indicador en el área de notificación. Asegúrese de que tiene instalada esta extensión antes de continuar:&lt;br&gt;&lt;br&gt;&lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../util/platform.cpp" line="+147"/>
@@ -198,7 +198,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+9"/>
         <source>Device name:</source>
-        <translation>Nombre de aparato:</translation>
+        <translation>Nombre del dispositivo:</translation>
     </message>
     <message>
         <location line="+19"/>
@@ -221,12 +221,12 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+7"/>
         <source>Allow local applications to interact with NitroShare</source>
-        <translation>Permita applicaciónes local a interactuar con NitroShare</translation>
+        <translation>Permitir que las aplicaciones locales puedan interactuar con NitroShare</translation>
     </message>
     <message>
         <location line="+7"/>
         <source>Auto start after login</source>
-        <translation>Comenzar automáticamente después de login</translation>
+        <translation>iniciará automáticamente después de inicio de sesión</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -251,7 +251,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+7"/>
         <source>Private key:</source>
-        <translation>Clave privado:</translation>
+        <translation>Clave privada:</translation>
     </message>
     <message>
         <location line="+7"/>
@@ -261,7 +261,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+55"/>
         <source>Private key passphrase:</source>
-        <translation>Contraseña de clave privado:</translation>
+        <translation>Contraseña de clave privada:</translation>
     </message>
     <message>
         <location line="+21"/>
@@ -313,17 +313,17 @@ Descripción: &quot;%2&quot;</translation>
         <location line="+16"/>
         <location line="+29"/>
         <source> sec</source>
-        <translation> sec</translation>
+        <translation> seg</translation>
     </message>
     <message>
         <location line="+32"/>
         <source>Broadcast Settings</source>
-        <translation>Preferencias de Transmitir</translation>
+        <translation>Preferencias para Transmitir</translation>
     </message>
     <message>
         <location line="+13"/>
         <source>Transfer Settings</source>
-        <translation>Preferencias de Transferencia</translation>
+        <translation>Preferencias para Transferencia</translation>
     </message>
     <message>
         <location line="+13"/>
@@ -338,7 +338,7 @@ Descripción: &quot;%2&quot;</translation>
     <message>
         <location line="+0"/>
         <source>Cannot enable or disable auto-start.</source>
-        <translation>No puede permitir o apagar comienzo automático.</translation>
+        <translation>No se puede habilitar o deshabilitar el inicio automático.</translation>
     </message>
     <message>
         <location line="+13"/>
@@ -385,7 +385,7 @@ Descripción: &quot;%2&quot;</translation>
 To transfer files, use the menu item in your system tray. After selecting the files you want to transfer, simply select the device you want to transfer them to and they will be instantly transferred.</source>
         <translation>NitroShare es una applicación de PC que permita un método fácil parta transferir archivos de un aparato a un otro.
 
-Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoger tus archivos, simplamente seleccionar el aparato que quieras usar por la destinación, y NitroShare los transferiré instantáneamente.</translation>
+Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoger tus archivos, simplamente seleccionar el dispositivo que quieras usar como destino, y NitroShare los transferiré instantáneamente.</translation>
     </message>
 </context>
 <context>
@@ -393,7 +393,7 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location filename="../../transfer/transfer.cpp" line="+73"/>
         <source>Transfer was canceled</source>
-        <translation>Transferencia fue cancelado</translation>
+        <translation>La Transferencia fue cancelada</translation>
     </message>
     <message>
         <location line="+73"/>
@@ -403,12 +403,12 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location line="+141"/>
         <source>Unable to read JSON packet</source>
-        <translation>No puedo leer el paquete JSON</translation>
+        <translation>No se puede leer paquetes JSON/translation>
     </message>
     <message>
         <location line="+12"/>
         <source>Unrecognized packet received</source>
-        <translation>Recibí paquete desconocido</translation>
+        <translation>Paquete recibido no reconocido</translation>
     </message>
 </context>
 <context>
@@ -416,7 +416,7 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location filename="../../transfer/transfermodel.cpp" line="+204"/>
         <source>Connecting</source>
-        <translation>Connectando</translation>
+        <translation>Conectando</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -431,12 +431,12 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location line="+2"/>
         <source>Succeeded</source>
-        <translation>Triunfó</translation>
+        <translation>Satisfactorio</translation>
     </message>
     <message>
         <location line="+54"/>
         <source>Device Name</source>
-        <translation>Nombre de Aparato</translation>
+        <translation>Nombre del dispositivo</translation>
     </message>
     <message>
         <location line="+2"/>
@@ -460,17 +460,17 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
         <location line="-182"/>
         <location line="+17"/>
         <source>Unable to open %1</source>
-        <translation>No puedo abrir: %1</translation>
+        <translation>No se pudo abrir: %1</translation>
     </message>
     <message>
         <location line="-11"/>
         <source>%1 is not a valid CA certificate</source>
-        <translation>%1 es no un CA certificado válido</translation>
+        <translation>%1 no es un certificado CA válido</translation>
     </message>
     <message>
         <location line="+17"/>
         <source>Unable to load private key %1</source>
-        <translation>No puedo cargar clave privado: %1</translation>
+        <translation>No se pudo cargar la clave privada: %1</translation>
     </message>
 </context>
 <context>
@@ -483,53 +483,53 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location line="+26"/>
         <source>Unexpected JSON packet received</source>
-        <translation>Pqaueta de JSON inesperado recibió</translation>
+        <translation>Inesperado Paquete JSON recibido</translation>
     </message>
     <message>
         <location line="+15"/>
         <source>Binary packet received before item header</source>
-        <translation>Paquete binario recibió ántes del titulo de artículo</translation>
+        <translation>Paquete binario recibido antes de encabezado del elemento</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Binary packet exceeds declared size</source>
-        <translation>Paquete binario excede tamaño declarado</translation>
+        <translation>Paquete binario excede el tamaño declarado</translation>
     </message>
     <message>
         <location line="+21"/>
         <source>Unexpected binary packet received</source>
-        <translation>Paquete binario inesperado recibió</translation>
+        <translation>Inesperado Paquete binario recibido</translation>
     </message>
     <message>
         <location line="+25"/>
         <source>Unable to read transfer header</source>
-        <translation>No puedo leer titulo de transferencia</translation>
+        <translation>No se puede leer encabezado de transferencia</translation>
     </message>
     <message>
         <location line="+9"/>
         <source>Item header received before previous file contents</source>
-        <translation>Titulo de artículo recibió ántes de los contentidos  de los archivos anteriores</translation>
+        <translation>Artículo recibido, encabezado antes del contenido de los archivos anteriores</translation>
     </message>
     <message>
         <location line="+27"/>
         <location line="+17"/>
         <source>Unable to create %1</source>
-        <translation>No puedo crear: %1</translation>
+        <translation>No se pudo crear: %1</translation>
     </message>
     <message>
         <location line="-6"/>
         <source>File size is missing from item header</source>
-        <translation>Tamaño del archivo de titulo de artículo no existe</translation>
+        <translation>Tamaño del archivo no se encuentra en el encabezado del elemento</translation>
     </message>
     <message>
         <location line="+13"/>
         <source>Unable to open %1</source>
-        <translation>No puedo abrir: %1</translation>
+        <translation>No se pudo abrir: %1</translation>
     </message>
     <message>
         <location line="+13"/>
         <source>Unable to read file header</source>
-        <translation>No puedo leer el titulo de archivo</translation>
+        <translation>No se pudo leer el titulo de archivo</translation>
     </message>
 </context>
 <context>
@@ -537,22 +537,22 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location filename="../../transfer/transfersender.cpp" line="+66"/>
         <source>Unexpected JSON packet received</source>
-        <translation>Pqaueta de JSON inesperado recibió</translation>
+        <translation>Inesperado Paquete JSON recibido</translation>
     </message>
     <message>
         <location line="+6"/>
         <source>Unexpected binary packet received</source>
-        <translation>Paquete binario inesperado recibió</translation>
+        <translation>Inesperado Paquete binario recibido</translation>
     </message>
     <message>
         <location line="+59"/>
         <source>Unable to open %1</source>
-        <translation>No puedo abrir: %1</translation>
+        <translation>No se pudo abrir: %1</translation>
     </message>
     <message>
         <location line="+28"/>
         <source>Unable to read from %1</source>
-        <translation>No puedo leer de %1</translation>
+        <translation>No se pudo leer desde %1</translation>
     </message>
 </context>
 <context>
@@ -560,7 +560,7 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location filename="../../transfer/transferserver.cpp" line="+45"/>
         <source>Unable to listen on port %1</source>
-        <translation>No piedo escuchar en puerto %1</translation>
+        <translation>No se ha podido escuchar en el puerto %1</translation>
     </message>
 </context>
 <context>
@@ -583,7 +583,7 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location line="+14"/>
         <source>Clear</source>
-        <translation>Despejar</translation>
+        <translation>Limpiar</translation>
     </message>
     <message>
         <location filename="../../transfer/transferwindow.cpp" line="+219"/>
@@ -598,7 +598,7 @@ Para transferir archivos, usa el menú en tu bandeja sistema. Después de escoge
     <message>
         <location line="+7"/>
         <source>Dismiss</source>
-        <translation>Despedir</translation>
+        <translation>Rechazar</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Spanish language nitroshare misspelling for the language,
